### PR TITLE
Fixed class configuration

### DIFF
--- a/famapy/core/models/configuration.py
+++ b/famapy/core/models/configuration.py
@@ -1,10 +1,7 @@
-from abc import ABC, abstractmethod
-
-from famapy.core.models.variability_model import VariabilityModel
+from typing import Any
 
 
-class Configuration(ABC):
+class Configuration():
 
-    @abstractmethod
-    def __init__(self, elements: dict[VariabilityModel, bool]) -> None:
+    def __init__(self, elements: dict[Any, bool]) -> None:
         self.elements = elements


### PR DESCRIPTION
The class configuration must not be abstrac, must be common for all the metamodels. And the dict of elements must be a dict of [feature, bool] instead of [VariabilityModel, bool]. Since the class Feature is part of some metamodel, and any metamodel can implements it, I change the Variability model for the typing Any.